### PR TITLE
flex-basis: only warn if direction is set and value is other than auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The rule complains when it finds:
 -   `position: static` used with `top`, `right`, `bottom`, `left` or `z-index`.
 -   `position: absolute` used with `float`, `clear` or `vertical-align`.
 -   `position: fixed` used with `float`, `clear` or `vertical-align`.
--   `flex-basis` used with `width` or `height`.
+-   `flex-basis` + `flex-direction: row` used with `width`.
+-   `flex-basis` + `flex-direction: column` used with `height`.
 -   `list-style-type: none` used with `list-style-image`.
 -   `overflow: visible` used with `resize`.
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -197,6 +197,30 @@ testRule(rule, {
     {
       code:
         ".a { display: inline; width: 100px; display: inline-block; } .b { display: inline; width: 100px; display: inline-block; }"
+    },
+    {
+      code: "a { flex-basis: auto; width: 100px; }",
+      description: "flex-basis: auto does not rule out width"
+    },
+    {
+      code: "a { flex-basis: auto; flex-direction: row; width: 100px; }",
+      description: "flex-basis: auto does not rule out width"
+    },
+    {
+      code: "a { flex-basis: 3px; width: 100px; }",
+      description: "flex-basis without flex-direction does not rule out width"
+    },
+    {
+      code: "a { flex-basis: auto; height: 100px; }",
+      description: "flex-basis: auto does not rule out height"
+    },
+    {
+      code: "a { flex-basis: auto; flex-direction: column; height: 100px; }",
+      description: "flex-basis: auto does not rule out height"
+    },
+    {
+      code: "a { flex-basis: 3px; height: 100px; }",
+      description: "flex-basis without flex-direction does not rule out height"
     }
   ],
 
@@ -592,32 +616,18 @@ testRule(rule, {
       description: "position: absolute rules out float"
     },
     {
-      code: "a { flex-basis: 3px; width: 100px; }",
+      code: "a { flex-basis: 3px; flex-direction: row; width: 100px; }",
       message: messages.rejected("width", "flex-basis: 3px"),
       line: 1,
-      column: 22,
-      description: "flex-basis rules out width"
+      column: 43,
+      description: "flex-basis + flex-direction: row rules out width"
     },
     {
-      code: "a { flex-basis: auto; width: 100px; }",
-      message: messages.rejected("width", "flex-basis: auto"),
-      line: 1,
-      column: 23,
-      description: "flex-basis rules out width"
-    },
-    {
-      code: "a { flex-basis: 3px; height: 100px; }",
+      code: "a { flex-basis: 3px; flex-direction: column; height: 100px; }",
       message: messages.rejected("height", "flex-basis: 3px"),
       line: 1,
-      column: 22,
-      description: "flex-basis rules out height"
-    },
-    {
-      code: "a { flex-basis: auto; height: 100px; }",
-      message: messages.rejected("height", "flex-basis: auto"),
-      line: 1,
-      column: 23,
-      description: "flex-basis rules out height"
+      column: 46,
+      description: "flex-basis + flex-direction: column rules out height"
     },
     {
       code:


### PR DESCRIPTION
I suspected that there was something weird in my previous PR #35 with the `flex-basis` property and `width`/ `height` property being ignored.

The useless-css-properties list only mentions this:
> width/height have no effect on this element since flex-basis is already defined

...but it turns out that it is not quite that simple. The fact that `width` or `height` is ignored seems to also depend on the value of `flex-basis` and the `flex-direction` property and value.

I found this article that has a deeper look at `flex-basis` vs `width`:
https://medium.freecodecamp.org/flexboxs-flex-basis-explained-83d1a01413b7

Here are some quotes from the article:

> - Flex-basis controls either “width” or “height” based on the flex-direction
> - Flex-basis will override any other width: or height: properties if specifically declared anything other than flex-basis: auto (auto by default)
> - Flex-basis will still obey any min / max-width: or height settings. Again, it is based on the flex-direction:

> Notice how auto is bold. By default, if you have a width set and did not declare a flex basis value, width will function normally on that element. There is no difference between how flex-basis: will function on your element and how width: will function on your element. Width will even obey flex-shrink when using Flexbox.
