### PR TITLE
Remove flex-basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The rule complains when it finds:
 -   `position: static` used with `top`, `right`, `bottom`, `left` or `z-index`.
 -   `position: absolute` used with `float`, `clear` or `vertical-align`.
 -   `position: fixed` used with `float`, `clear` or `vertical-align`.
--   `flex-basis` used with `width` or `height`.
 -   `list-style-type: none` used with `list-style-image`.
 -   `overflow: visible` used with `resize`.
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -592,34 +592,6 @@ testRule(rule, {
       description: "position: absolute rules out float"
     },
     {
-      code: "a { flex-basis: 3px; width: 100px; }",
-      message: messages.rejected("width", "flex-basis: 3px"),
-      line: 1,
-      column: 22,
-      description: "flex-basis rules out width"
-    },
-    {
-      code: "a { flex-basis: auto; width: 100px; }",
-      message: messages.rejected("width", "flex-basis: auto"),
-      line: 1,
-      column: 23,
-      description: "flex-basis rules out width"
-    },
-    {
-      code: "a { flex-basis: 3px; height: 100px; }",
-      message: messages.rejected("height", "flex-basis: 3px"),
-      line: 1,
-      column: 22,
-      description: "flex-basis rules out height"
-    },
-    {
-      code: "a { flex-basis: auto; height: 100px; }",
-      message: messages.rejected("height", "flex-basis: auto"),
-      line: 1,
-      column: 23,
-      description: "flex-basis rules out height"
-    },
-    {
       code:
         "a { list-style-type: none; list-style-image: url('starsolid.gif'); }",
       message: messages.rejected("list-style-image", "list-style-type: none"),

--- a/index.js
+++ b/index.js
@@ -116,11 +116,6 @@ const ignored = [
     ignoredProperties: ["float", "clear", "vertical-align"]
   },
   {
-    property: "flex-basis",
-    value: "/^.*$/",
-    ignoredProperties: ["width", "height"]
-  },
-  {
     property: "list-style-type",
     value: "none",
     ignoredProperties: ["list-style-image"]


### PR DESCRIPTION
Remove `flex-basis` as it also depends on `flex-direction` being set on the parent/container element.

Source: 
https://medium.freecodecamp.org/flexboxs-flex-basis-explained-83d1a01413b7

> - Flex-basis controls either “width” or “height” based on the flex-direction
> - Flex-basis will override any other width: or height: properties if specifically declared anything other than flex-basis: auto (auto by default)
> - Flex-basis will still obey any min / max-width: or height settings. Again, it is based on the flex-direction:

> Notice how auto is bold. By default, if you have a width set and did not declare a flex basis value, width will function normally on that element. There is no difference between how flex-basis: will function on your element and how width: will function on your element. Width will even obey flex-shrink when using Flexbox.