### PR TITLE
Remove PostCSS dependency

### DIFF
--- a/__tests__/utils/vendorPrefixes.js
+++ b/__tests__/utils/vendorPrefixes.js
@@ -1,0 +1,18 @@
+const vendorPrefixes = require("../../utils/vendorPrefixes");
+
+describe("utils/vendorPrefixes", () => {
+  it("should return the vendor prefix when it is specified", () => {
+    expect(vendorPrefixes.prefix("-moz-tab-size")).toBe("-moz-");
+    expect(vendorPrefixes.prefix("-webkit-tab-size")).toBe("-webkit-");
+    expect(vendorPrefixes.prefix("-whatever-tab-size")).toBe("-whatever-");
+  });
+
+  it("should return an empty string is the prefix is not present", () => {
+    expect(vendorPrefixes.prefix("tab-size")).toBe("");
+  });
+
+  it("should return the unprefixed version of CSS rule", () => {
+    expect(vendorPrefixes.unprefixed("-moz-tab-size")).toBe("tab-size");
+    expect(vendorPrefixes.unprefixed("tab-size")).toBe("tab-size");
+  });
+});

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const matchesStringOrRegExp = require("./utils/matchesStringOrRegExp");
-const postcss = require("postcss");
 const stylelint = require("stylelint");
+const vendorPrefixes = require("./utils/vendorPrefixes");
 const report = stylelint.utils.report;
 const ruleMessages = stylelint.utils.ruleMessages;
 const validateOptions = stylelint.utils.validateOptions;
@@ -144,8 +144,8 @@ const rule = (actual) => {
       function check(prop, index) {
         const decl = uniqueDecls[prop];
         const value = decl.value;
-        const unprefixedProp = postcss.vendor.unprefixed(prop);
-        const unprefixedValue = postcss.vendor.unprefixed(value);
+        const unprefixedProp = vendorPrefixes.unprefixed(prop);
+        const unprefixedValue = vendorPrefixes.unprefixed(value);
 
         ignored.forEach((ignore) => {
           const matchProperty = matchesStringOrRegExp(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1800,6 +1800,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2266,6 +2267,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2444,6 +2446,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2451,7 +2454,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colorette": {
       "version": "1.2.2",
@@ -2841,7 +2845,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "2.0.0",
@@ -3716,7 +3721,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -6895,6 +6901,7 @@
       "version": "7.0.36",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
       "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -6904,12 +6911,14 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7973,6 +7982,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "bugs": {
     "url": "https://github.com/kristerkari/stylelint-declaration-block-no-ignored-properties/issues"
   },
-  "dependencies": {
-    "postcss": "^7.0.27"
-  },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "eslint": "^7.31.0",

--- a/utils/vendorPrefixes.js
+++ b/utils/vendorPrefixes.js
@@ -1,0 +1,42 @@
+/**
+ * Contains helpers for working with vendor prefixes.
+ *
+ * @namespace vendor
+ */
+const vendor = {
+  /**
+   * Returns the vendor prefix extracted from an input string.
+   *
+   * @param {string} prop String with or without vendor prefix.
+   *
+   * @return {string} vendor prefix or empty string
+   *
+   * @example
+   * vendorPrefixes.prefix('-moz-tab-size') //=> '-moz-'
+   * vendorPrefixes.prefix('tab-size')      //=> ''
+   */
+  prefix(prop) {
+    const match = prop.match(/^(-\w+-)/);
+    if (match) {
+      return match[0];
+    }
+
+    return "";
+  },
+
+  /**
+   * Returns the input string stripped of its vendor prefix.
+   *
+   * @param {string} prop String with or without vendor prefix.
+   *
+   * @return {string} String name without vendor prefixes.
+   *
+   * @example
+   * vendorPrefixes.unprefixed('-moz-tab-size') //=> 'tab-size'
+   */
+  unprefixed(prop) {
+    return prop.replace(/^-\w+-/, "");
+  }
+};
+
+module.exports = vendor;


### PR DESCRIPTION
The PostCSS "vendor" API was removed in version 8, so copy the functions over and remove PostCSS as a dependency.

Closes #63